### PR TITLE
Ajout du réseau de transport Imagine

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -62,6 +62,9 @@ datasets:
   # Metz (réseau Le Met')
   - slug: fichiers-gtfs-eurometropole-de-metz
     prefix: fr-metz
+  # Epinal (réseau Imagine)
+  - slug: fr-200052264-t0009-0000-1
+    prefix: fr-epinal
   
 # DATASETS PRIVÉS
   # SNCF


### PR DESCRIPTION
Ajout du réseau de bus Imagine d'Epinal
https://transport.data.gouv.fr/datasets/fr-200052264-t0009-0000-1
Le préfixe à vraiment un intérêt avec des ID pareil :)