### PR TITLE
Ajout du réseau Stan de Nancy

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -62,6 +62,9 @@ datasets:
   # Metz (réseau Le Met')
   - slug: fichiers-gtfs-eurometropole-de-metz
     prefix: fr-metz
+    # Nancy (réseau Stan)
+  - slug: arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs
+    prefix: fr-nancy
   
 # DATASETS PRIVÉS
   # SNCF


### PR DESCRIPTION
https://transport.data.gouv.fr/datasets/arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs