### PR TITLE
Ajout du réseau Sub de Nancy

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -101,6 +101,9 @@ datasets:
   # Nancy (réseau Stan)
   - slug: arrets-horaires-et-parcours-theoriques-du-reseau-stan-gtfs
     prefix: fr-nancy
+  # Nancy (réseau Sub)
+  - slug: fr-200052264-t0039-0000-1
+    prefix: fr-nancy-sub
   # Epinal (réseau Imagine)
   - slug: fr-200052264-t0009-0000-1
     prefix: fr-epinal


### PR DESCRIPTION
On continue de donner a manger a Mottis, pour le moment je me focus sur le Grand Est, il faudrait voir s'il manque encore de grande ville à intégrer
https://transport.data.gouv.fr/datasets/fr-200052264-t0039-0000-1