### PR TITLE
hide all POIs with access=private or access=no

### DIFF
--- a/tilemaker/resources/process-openmaptiles.lua
+++ b/tilemaker/resources/process-openmaptiles.lua
@@ -203,7 +203,7 @@ function node_function()
 	-- Write 'poi'
 	local rank, class, subclass = GetPOIRank()
 	local access = Find("access")
-	if rank and access ~= "private" and access ~= "no" then
+	if rank and not isHiddenPrivatePOI() then
 		WritePOI(class,subclass,rank,'n')
 	end
 
@@ -690,6 +690,7 @@ function way_function()
 	end
 
 	-- Set 'water'
+	-- (therefore leisure==swimming_pool are only added in this water layer and not in the poi layer )
 	if natural=="water" or leisure=="swimming_pool" or landuse=="reservoir" or landuse=="basin" or waterClasses[waterway] then
 		if Find("covered")=="yes" or not is_closed then return end
 		local class="lake"; if waterway~="" then class="river" end
@@ -763,7 +764,7 @@ function way_function()
 	local isRelation = IsMultiPolygon()
 	local nwr = isRelation and 'r' or 'w'
 	local access = Find("access")
-	if rank and access ~= "private" and access ~= "no" then
+	if rank and not isHiddenPrivatePOI()  then
 		WritePOI(class,subclass,rank, nwr)
 		return
 	end
@@ -990,6 +991,26 @@ function SetZOrder()
 	end
 	zOrder = zOrder + hwClass
 	ZOrder(zOrder)
+end
+
+-- function to list the private POI which need to be removed from the POI layer
+function isHiddenPrivatePOI()
+	local access = Find("access")
+	if access == "private" or access == "no" then
+		--key amenity
+		local amenity = Find("amenity")
+		if amenity == "parking" then return true end
+		--key leisure (swimming_pool not listed here since they are not in the POI layer but only their geometries in the water layer)
+		local leisure = Find("leisure")
+		if leisure == "garden" then return true end
+		if leisure == "pitch" then return true end
+		if leisure == "playground" then return true end
+		--key sport
+		local sport = Find("sport")
+		if sport == "tennis" then return true end
+		if sport == "swimming" then return true end
+	end
+	return false
 end
 
 -- ==========================================================

--- a/tilemaker/resources/process-openmaptiles.lua
+++ b/tilemaker/resources/process-openmaptiles.lua
@@ -202,7 +202,10 @@ function node_function()
 
 	-- Write 'poi'
 	local rank, class, subclass = GetPOIRank()
-	if rank then WritePOI(class,subclass,rank,'n') end
+	local access = Find("access")
+	if rank and access ~= "private" and access ~= "no" then
+		WritePOI(class,subclass,rank,'n')
+	end
 
 	-- Write 'mountain_peak' and 'water_name'
 	local natural = Find("natural")
@@ -758,8 +761,12 @@ function way_function()
 	local rank, class, subclass = GetPOIRank()
 	
 	local isRelation = IsMultiPolygon()
-  local nwr = isRelation and 'r' or 'w'
-	if rank then WritePOI(class,subclass,rank, nwr); return end
+	local nwr = isRelation and 'r' or 'w'
+	local access = Find("access")
+	if rank and access ~= "private" and access ~= "no" then
+		WritePOI(class,subclass,rank, nwr)
+		return
+	end
 
 	-- Catch-all
 	if (building~="" or write_name) and Holds("name") then


### PR DESCRIPTION
This PR modifies the `process-openmaptiles.lua` tiles processing script to hide all the POIs which have tag `access=private` or `access=no`. (This only applies to the poi layer, and not to the other OMT layers)

resolves https://github.com/cartesapp/cartes/issues/860 which was specific for `amenity=parking` but it sounds logical to me to hide all other private elements. This is something we can discuss and modify if this proposal hides too many things, for example if some private elements have to be visible in the tiles (nothing comes to my mind at the moment).

The modification have been successfully tested:

- before
![image](https://github.com/user-attachments/assets/a1ad6085-10a5-4693-b07c-001a64ed5d48)

- after
![image](https://github.com/user-attachments/assets/28741955-12d6-491a-a32b-45ed42cdcce2)
