### PR TITLE
add big rivers in tiles waterway layer zoom levels 3 to 7

### DIFF
--- a/tilemaker/resources/config-openmaptiles.json
+++ b/tilemaker/resources/config-openmaptiles.json
@@ -33,6 +33,12 @@
       "simplify_ratio": 2
     },
     "waterway_detail": { "minzoom": 12, "maxzoom": 14, "write_to": "waterway" },
+    "waterway_big": {
+      "minzoom": 3,
+      "maxzoom": 7,
+      "simplify_below": 6,
+      "write_to": "waterway"
+    },
 
     "transportation": {
       "minzoom": 4,

--- a/tilemaker/resources/process-openmaptiles.lua
+++ b/tilemaker/resources/process-openmaptiles.lua
@@ -642,6 +642,9 @@ function way_function()
 	-- Set 'waterway' and associated
 	if waterwayClasses[waterway] and not is_closed then
 		if waterway == "river" and Holds("name") then
+			if isBigRiver() then
+				Layer("waterway_big", false)
+			end
 			Layer("waterway", false)
 	    Attribute("nwr", "w")
 		else
@@ -1001,3 +1004,19 @@ function split(inputstr, sep) -- https://stackoverflow.com/a/7615129/4288232
 end
 
 -- vim: tabstop=2 shiftwidth=2 noexpandtab
+
+-- Function to test if a value is in a table
+function contains(table, val)
+    for i = 1, #table do
+        if table[i] == val then
+            return true
+        end
+    end
+    return false
+end
+
+-- Function to test if a river is big (manual definition by list of names)
+bigRivers={"L'adour", "La Garonne", "La Loire", "La Meuse", "Le Rhin", "Vieux Rhin", "Rhine", "Le Rhône", "La Seine"}
+function isBigRiver()
+	return contains(bigRivers, Find("name")) or contains(bigRivers, Find("name:fr")) or contains(bigRivers, Find("name:en"))
+end


### PR DESCRIPTION
Cette PR participe à la résolution de https://github.com/cartesapp/cartes/issues/968 en gérant l'inclusion des fleuves dans les tuiles de faible zoom (il faudra aussi modifier `france.ts` dans `\cartes`)

Les rivières sont en triple dans les tuiles : 
- l'emprise du lit en Polygon dans le layer `water`
- le nom en Point et LineString dans le layer `water_name`
- le tracé en LineString dans le layer `waterway`

Donc pas besoin d'étendre des Polygon de `water` pour les voir à faible zoom, on pourra utiliser les LineString de `waterway` sauf que pas de bol ils ne sont présents que dans les tuiles de zoom >= 8.

Donc pour inclure les fleuves dans les tuiles, j'ai :
- créé une liste de nom de fleuves qu'on veut afficher
  - pas hyper satisfaisant comme méthode, mais il n'y a pas de tag spécifique pour les distinguer
- ajouté un test `isBigRiver` qui permet de les ajouter dans un layer provisoire `waterway_big`
- et ce layer provisoire est renvoyé dans les tuiles de zoom 3 à 7 inclus du layer `waterway`

@laem je n'ai pas pu tester sur la france entière, seulement sur les différents extraits .osm.pbf de régions qui m'ont permis de mettre au point le script. Ca marche bien, je suis assez confiant pour le cas France augmentée (d'autant que ça ne fait que ajouter des données en plus dans des tuiles, et tout l'existant est conservé à l'identique).

Exemple : 1 morceau de la Seine et 2 morceaux de la Meuse qui passent en Champagne-Ardennes, à zoom 6
![image](https://github.com/user-attachments/assets/14c08937-33b4-43dc-83a4-df03f4a7e7b4)
